### PR TITLE
Functionality for A Star to Bookmark MUC

### DIFF
--- a/Swift/QtUI/QtChatWindow.cpp
+++ b/Swift/QtUI/QtChatWindow.cpp
@@ -93,6 +93,11 @@ QtChatWindow::QtChatWindow(const QString& contact, QtChatTheme* theme, UIEventSt
 	setSubject("");
 	subject_->setReadOnly(true);
 
+	bookmarkStar_ = new QPushButton(this);
+	connect(bookmarkStar_, SIGNAL(clicked()), this, SLOT(onBookmarkStarClicked()));
+	subjectLayout_->addWidget(bookmarkStar_);
+	bookmarkStar_->hide();
+
 	QPushButton* actionButton_ = new QPushButton(this);
 	actionButton_->setIcon(QIcon(":/icons/actions.png"));
 	connect(actionButton_, SIGNAL(clicked()), this, SLOT(handleActionButtonClicked()));
@@ -459,6 +464,7 @@ void QtChatWindow::convertToMUC(MUCType mucType) {
 	isMUC_ = true;
 	treeWidget_->show();
 	subject_->setVisible(!impromptu_);
+	bookmarkStar_->setVisible(true);
 }
 
 void QtChatWindow::setOnline(bool online) {
@@ -684,6 +690,10 @@ void QtChatWindow::handleTextInputReceivedFocus() {
 
 void QtChatWindow::handleTextInputLostFocus() {
 	lastLineTracker_.setHasFocus(false);
+}
+
+void QtChatWindow::onBookmarkStarClicked() {
+        onBookmarkRequest();
 }
 
 void QtChatWindow::handleActionButtonClicked() {
@@ -942,6 +952,10 @@ void QtChatWindow::setMessageReceiptState(const std::string& id, ChatWindow::Rec
 
 void QtChatWindow::setBookmarkState(RoomBookmarkState bookmarkState) {
 	roomBookmarkState_ = bookmarkState;
-}
-
+	if (roomBookmarkState_ == RoomNotBookmarked) {
+        	bookmarkStar_->setIcon(QIcon("../resources/icons/star-unchecked2.png"));
+        }
+	else {
+        	bookmarkStar_->setIcon(QIcon("../resources/icons/star-checked2.png"));
+        }
 }

--- a/Swift/QtUI/QtChatWindow.h
+++ b/Swift/QtUI/QtChatWindow.h
@@ -174,6 +174,7 @@ namespace Swift {
 			void handleEmoticonClicked(QString emoticonAsText);
 			void handleTextInputReceivedFocus();
 			void handleTextInputLostFocus();
+                        void onBookmarkStarClicked();	
 
 		private:
 			void updateTitleWithUnreadCount();
@@ -230,5 +231,6 @@ namespace Swift {
 			bool supportsImpromptuChat_;
 			RoomBookmarkState roomBookmarkState_;
 			QMenu* emoticonsMenu_;
+                        QPushButton* bookmarkStar_;
 	};
 }


### PR DESCRIPTION
Added a star to the top bar of a MUC (beside the subject). Grey when the MUC isn't bookmarked, and yellow if it is. Clicking it pops up the bookmark/unbookmark/edit bookmark widget.