### PR TITLE
Fixed a typo in InstallSwiftDependencies.sh

### DIFF
--- a/BuildTools/InstallSwiftDependencies.sh
+++ b/BuildTools/InstallSwiftDependencies.sh
@@ -28,5 +28,5 @@ then
 		echo "Unsupported Linux distribution."
 	fi
 else
-	echo "Unspupported system."
+	echo "Unsupported system."
 fi


### PR DESCRIPTION
License:
This patch is BSD-licensed, see Documentation/Licenses/BSD-simplified.txt for details.


The file displayed Unspupported System when you ran ./BuildTools/InstallSwiftDependencies.sh on a system not included in the Unix Distribution. The typo was fixed, and it now shows Unsupported System.