### PR TITLE
Include missing cassert

### DIFF
--- a/Swiften/Parser/ExpatParser.cpp
+++ b/Swiften/Parser/ExpatParser.cpp
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include <cassert>
+
 #include <expat.h>
 
 #include <boost/numeric/conversion/cast.hpp>

--- a/Swiften/Parser/PayloadParsers/CommandParser.cpp
+++ b/Swiften/Parser/PayloadParsers/CommandParser.cpp
@@ -6,6 +6,8 @@
 
 #include <Swiften/Parser/PayloadParsers/CommandParser.h>
 
+#include <cassert>
+
 #include <boost/cast.hpp>
 
 #include <Swiften/Parser/PayloadParsers/FormParser.h>

--- a/Swiften/Parser/PayloadParsers/DiscoInfoParser.cpp
+++ b/Swiften/Parser/PayloadParsers/DiscoInfoParser.cpp
@@ -6,6 +6,8 @@
 
 #include <Swiften/Parser/PayloadParsers/DiscoInfoParser.h>
 
+#include <cassert>
+
 #include <boost/optional.hpp>
 
 #include <Swiften/Parser/PayloadParsers/FormParser.h>

--- a/Swiften/Parser/PayloadParsers/InBandRegistrationPayloadParser.cpp
+++ b/Swiften/Parser/PayloadParsers/InBandRegistrationPayloadParser.cpp
@@ -6,6 +6,8 @@
 
 #include <Swiften/Parser/PayloadParsers/InBandRegistrationPayloadParser.h>
 
+#include <cassert>
+
 #include <boost/cast.hpp>
 
 #include <Swiften/Parser/PayloadParsers/FormParser.h>

--- a/Swiften/Parser/PayloadParsers/RosterParser.cpp
+++ b/Swiften/Parser/PayloadParsers/RosterParser.cpp
@@ -6,6 +6,8 @@
 
 #include <Swiften/Parser/PayloadParsers/RosterParser.h>
 
+#include <cassert>
+
 #include <boost/optional.hpp>
 
 #include <Swiften/Parser/SerializingParser.h>

--- a/Swiften/Parser/PayloadParsers/SearchPayloadParser.cpp
+++ b/Swiften/Parser/PayloadParsers/SearchPayloadParser.cpp
@@ -6,6 +6,8 @@
 
 #include <Swiften/Parser/PayloadParsers/SearchPayloadParser.h>
 
+#include <cassert>
+
 #include <boost/cast.hpp>
 
 #include <Swiften/Parser/PayloadParsers/FormParser.h>

--- a/Swiften/Parser/PayloadParsers/StreamInitiationParser.cpp
+++ b/Swiften/Parser/PayloadParsers/StreamInitiationParser.cpp
@@ -9,6 +9,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/cast.hpp>
 
+#include <cassert>
+
 #include <Swiften/Parser/PayloadParsers/FormParserFactory.h>
 #include <Swiften/Parser/PayloadParsers/FormParser.h>
 #include <Swiften/Base/foreach.h>

--- a/Swiften/Parser/PayloadParsers/UnitTest/PayloadsParserTester.h
+++ b/Swiften/Parser/PayloadParsers/UnitTest/PayloadsParserTester.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <Swiften/Elements/Payload.h>
 #include <Swiften/Parser/PayloadParser.h>
 #include <Swiften/Parser/PayloadParsers/FullPayloadParserFactoryCollection.h>

--- a/Swiften/Parser/PayloadParsers/VCardParser.cpp
+++ b/Swiften/Parser/PayloadParsers/VCardParser.cpp
@@ -6,6 +6,8 @@
 
 #include <Swiften/Parser/PayloadParsers/VCardParser.h>
 
+#include <cassert>
+
 #include <Swiften/Base/DateTime.h>
 #include <Swiften/Base/foreach.h>
 #include <Swiften/Parser/SerializingParser.h>


### PR DESCRIPTION
Test-Information:
Build successfully on openSUSE Leap 41.2

License:
This patch is BSD-licensed, see
Documentation/Licenses/BSD-simplified.txt for details.