### PR TITLE
Add libQt5Svg5 to openSUSSE dependencies

### DIFF
--- a/BuildTools/InstallSwiftDependencies.sh
+++ b/BuildTools/InstallSwiftDependencies.sh
@@ -19,7 +19,7 @@ then
         sudo pacman -S qt5-base qt5-x11extras qt5-webkit qt5-multimedia qt5-tools hunspell
     elif [ "$SYSTEM_DISTRO" == "openSUSE project" ]
     then
-        sudo zypper in pkg-config libopenssl-devel libQt5Core-devel libQt5WebKit5-devel libQt5WebKitWidgets-devel libqt5-qtmultimedia-devel libqt5-qtx11extras-devel libqt5-qttools-devel libQt5Gui-devel libQt5Network-devel libQt5DBus-devel python-xml hunspell-devel
+        sudo zypper in pkg-config libopenssl-devel libQt5Core-devel libQt5WebKit5-devel libQt5WebKitWidgets-devel libqt5-qtmultimedia-devel libqt5-qtx11extras-devel libqt5-qttools-devel libQt5Gui-devel libQt5Network-devel libQt5DBus-devel python-xml hunspell-devel libQt5Svg5
     elif [ "$SYSTEM_DISTRO" == "Fedora" ]
     then
         sudo dnf groups install "C Development Tools and Libraries"


### PR DESCRIPTION
Needed for svg imageformat plugin.

License:
This patch is BSD-licensed, see
Documentation/Licenses/BSD-simplified.txt for details.