### PR TITLE
Bug Fix: Add Password Element to MUC User Element as in XEP-0045 Exam…

### DIFF
--- a/Swiften/Serializer/PayloadSerializers/MUCUserPayloadSerializer.cpp
+++ b/Swiften/Serializer/PayloadSerializers/MUCUserPayloadSerializer.cpp
@@ -36,6 +36,7 @@ std::string MUCUserPayloadSerializer::serializePayload(std::shared_ptr<MUCUserPa
     if (payload->getPassword()) {
         std::shared_ptr<XMLElement> passwordElement = std::make_shared<XMLElement>("password");
         passwordElement->addNode(std::make_shared<XMLTextNode>(*payload->getPassword()));
+        mucElement.addNode(passwordElement);
     }
 
     if (payload->getInvite()) {


### PR DESCRIPTION

License:
This patch is BSD-licensed, see Documentation/Licenses/BSD-simplified.txt for details.

Change-Id: Iae3c2c9eefb58cb27406e45f031c1adc5702ac13