### PR TITLE
add missing SWIFTEN_API declarations

### DIFF
--- a/Swiften/Base/Debug.h
+++ b/Swiften/Base/Debug.h
@@ -19,8 +19,8 @@ namespace boost {
     template<class T> class shared_ptr;
 }
 
-std::ostream& operator<<(std::ostream& os, const Swift::ClientError& error);
+SWIFTEN_API std::ostream& operator<<(std::ostream& os, const Swift::ClientError& error);
 
-std::ostream& operator<<(std::ostream& os, Swift::Element* ele);
+SWIFTEN_API std::ostream& operator<<(std::ostream& os, Swift::Element* ele);
 
-std::ostream& operator<<(std::ostream& os, Swift::ClientSession::State state);
+SWIFTEN_API std::ostream& operator<<(std::ostream& os, Swift::ClientSession::State state);

--- a/Swiften/Base/SafeAllocator.cpp
+++ b/Swiften/Base/SafeAllocator.cpp
@@ -13,7 +13,7 @@
 
 namespace Swift {
 
-void secureZeroMemory(char* memory, size_t numberOfBytes) {
+SWIFTEN_API void secureZeroMemory(char* memory, size_t numberOfBytes) {
 #ifdef SWIFTEN_PLATFORM_WINDOWS
     SecureZeroMemory(memory, numberOfBytes);
 #else

--- a/Swiften/Base/SafeAllocator.h
+++ b/Swiften/Base/SafeAllocator.h
@@ -12,7 +12,7 @@
 #include <Swiften/Base/API.h>
 
 namespace Swift {
-    void secureZeroMemory(char* memory, size_t numberOfBytes);
+    SWIFTEN_API void secureZeroMemory(char* memory, size_t numberOfBytes);
 
     template<typename T>
     class SWIFTEN_API SafeAllocator : public std::allocator<T> {


### PR DESCRIPTION
These APIs are used by Swiften QA tests and/or spectrum2 and should be exported from dll under Windows