### PR TITLE
fix failing tests under Windows

### DIFF
--- a/Swiften/FileTransfer/FileWriteBytestream.h
+++ b/Swiften/FileTransfer/FileWriteBytestream.h
@@ -19,7 +19,7 @@ namespace Swift {
             virtual ~FileWriteBytestream();
 
             virtual bool write(const std::vector<unsigned char>&);
-            void close();
+            virtual void close();
 
         private:
             boost::filesystem::path file;

--- a/Swiften/FileTransfer/WriteBytestream.h
+++ b/Swiften/FileTransfer/WriteBytestream.h
@@ -28,5 +28,7 @@ namespace Swift {
             virtual bool write(const std::vector<unsigned char>&) = 0;
 
             boost::signals2::signal<void (const std::vector<unsigned char>&)> onWrite;
+
+            virtual void close() {};
     };
 }

--- a/Swiften/QA/StorageTest/FileWriteBytestreamTest.cpp
+++ b/Swiften/QA/StorageTest/FileWriteBytestreamTest.cpp
@@ -34,7 +34,7 @@ class FileWriteBytestreamTest : public CppUnit::TestFixture {
 
             CPPUNIT_ASSERT_EQUAL(true, writeBytestream->write(createByteArray("Some data.")));
             CPPUNIT_ASSERT_EQUAL(true, onWriteWasCalled);
-
+            writeBytestream->close();
             boost::filesystem::remove(filename);
         }
 


### PR DESCRIPTION
This patch and corresponding patch with new SWIFTEN_API declarations make successful `swiften_dll=yes test=all` under Windows