### PR TITLE
Allow to override Swiften libdir

### DIFF
--- a/BuildTools/SCons/SConscript.boot
+++ b/BuildTools/SCons/SConscript.boot
@@ -426,6 +426,8 @@ for path in ["SWIFT_INSTALLDIR", "SWIFTEN_INSTALLDIR", "SLUIFT_INSTALLDIR"] :
             env[path] = Dir(ARGUMENTS[path]).abspath
         else :
             env[path] = Dir("#/" + ARGUMENTS[path]).abspath
+if ARGUMENTS.get("SWIFTEN_LIBDIR", "") :
+    env["SWIFTEN_LIBDIR"] = ARGUMENTS["SWIFTEN_LIBDIR"]
 
 
 ################################################################################

--- a/Swiften/SConscript
+++ b/Swiften/SConscript
@@ -635,8 +635,9 @@ if env["SCONS_STAGE"] == "build" :
 
     # Install swiften
     if swiften_env.get("SWIFTEN_INSTALLDIR", "") :
-        swiften_env.Install(os.path.join(swiften_env["SWIFTEN_INSTALLDIR"], "lib"), swiften_lib)
+        swiften_libdir = swiften_env.get("SWIFTEN_LIBDIR", "lib")
+        swiften_env.Install(os.path.join(swiften_env["SWIFTEN_INSTALLDIR"], swiften_libdir), swiften_lib)
         for alias in myenv["SWIFTEN_LIBRARY_ALIASES"] :
-            myenv.Command(myenv.File(os.path.join(swiften_env["SWIFTEN_INSTALLDIR"], "lib", alias)), [env.Value(swiften_lib[0].name), swiften_lib[0]], symlink)
+            myenv.Command(myenv.File(os.path.join(swiften_env["SWIFTEN_INSTALLDIR"], swiften_libdir, alias)), [env.Value(swiften_lib[0].name), swiften_lib[0]], symlink)
         for include in swiften_includes :
             swiften_env.Install(os.path.join(swiften_env["SWIFTEN_INSTALLDIR"], "include", os.path.dirname(include)), "#/" + include)


### PR DESCRIPTION
The libdir for Swiften was hardcoded to "lib". With this patch it is possible to override it.