### PR TITLE
Sort input file list

### DIFF
--- a/BuildTools/SCons/SConstruct
+++ b/BuildTools/SCons/SConstruct
@@ -707,6 +707,8 @@ if ARGUMENTS.get("replace_pragma_once", False) :
         return path[i+1:]
 
     for actual_root, dirs, files in os.walk(root) :
+        dirs.sort()
+        files.sort()
         if "3rdParty" in actual_root :
             continue
         for file in files :
@@ -733,14 +735,14 @@ if ARGUMENTS.get("dump_trace", False) :
 # Modules
 modules = []
 if os.path.isdir(Dir("#/3rdParty").abspath) :
-    for dir in os.listdir(Dir("#/3rdParty").abspath) :
+    for dir in sorted(os.listdir(Dir("#/3rdParty").abspath)) :
         full_dir = os.path.join(Dir("#/3rdParty").abspath, dir)
         if not os.path.isdir(full_dir) :
             continue
         sconscript = os.path.join(full_dir, "SConscript")
         if os.path.isfile(sconscript) :
             modules.append("3rdParty/" + dir)
-for dir in os.listdir(Dir("#").abspath) :
+for dir in sorted(os.listdir(Dir("#").abspath)) :
     full_dir = os.path.join(Dir("#").abspath, dir)
     if not os.path.isdir(full_dir) :
         continue

--- a/Swift/QtUI/SConscript
+++ b/Swift/QtUI/SConscript
@@ -10,6 +10,8 @@ def generateQRCTheme(dir, prefix) :
         #skip the Noto emoji fonts in Windows. No need to package them since they aren't used
         if "Noto" in path and not env["PLATFORM"] == "linux" :
             continue
+        dirs.sort()
+        files.sort()
         for file in files :
             filePath = os.path.join(path,file)
             result += "<file alias=\"%(alias)s\">%(path)s</file>" % {

--- a/Swiften/SConscript
+++ b/Swiften/SConscript
@@ -593,6 +593,8 @@ if env["SCONS_STAGE"] == "build" :
     swiften_public_includes = []
     top_path = env.Dir("..").abspath
     for root, dirs, files in os.walk(env.Dir(".").abspath) :
+        dirs.sort()
+        files.sort()
         if root.endswith("UnitTest") :
             continue
         for file in files :


### PR DESCRIPTION
Sort input file list
so that the swift-im openSUSE package (and likely others as well) builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

License:
This patch is BSD licensed - see Documentation/Licenses/BSD-simplified.txt for details.

Test-Information:
Builds on different machines should no longer have differences in
Swiften.h as observed currently in openSUSE Tumbleweed:
http://rb.zq1.de/compare.factory-20180228/swift-im-compare.out

Additionally, diffs in the swift-im binary should be reduced to those from Qt's rcc qrc timestamps ( https://bugreports.qt.io/browse/QTBUG-62511 )